### PR TITLE
Add namespace query parameter for registry mirroring/proxying

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -867,11 +867,7 @@ impl Client {
                 match digest {
                     Some(digest) => {
                         debug!("Selected manifest entry with digest: {}", digest);
-                        let manifest_entry_reference = Reference::with_digest(
-                            image.registry().to_string(),
-                            image.repository().to_string(),
-                            digest.clone(),
-                        );
+                        let manifest_entry_reference = image.clone_with_digest(digest.clone());
                         self._pull_manifest(&manifest_entry_reference)
                             .await
                             .and_then(|(manifest, _digest)| match manifest {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1094,7 +1094,7 @@ impl Client {
         offset: Option<u64>,
     ) -> Result<Response> {
         let layer = layer.as_layer_descriptor();
-        let url = self.to_v2_blob_url(image.resolve_registry(), image.repository(), layer.digest);
+        let url = self.to_v2_blob_url(image, layer.digest);
 
         let mut request = RequestBuilderWrapper::from_client(self, |client| client.get(&url))
             .apply_accept(MIME_TYPES_DISTRIBUTION_MANIFEST)?
@@ -1433,11 +1433,10 @@ impl Client {
     ) -> Result<String> {
         let lh = location_header.to_str()?;
         if lh.starts_with("/v2/") {
+            let registry = image.resolve_registry();
             Ok(format!(
-                "{}://{}{}",
-                self.config.protocol.scheme_for(image.resolve_registry()),
-                image.resolve_registry(),
-                lh
+                "{scheme}://{registry}{lh}",
+                scheme = self.config.protocol.scheme_for(registry)
             ))
         } else {
             Ok(lh.to_string())
@@ -1446,57 +1445,52 @@ impl Client {
 
     /// Convert a Reference to a v2 manifest URL.
     fn to_v2_manifest_url(&self, reference: &Reference) -> String {
-        if let Some(digest) = reference.digest() {
-            format!(
-                "{}://{}/v2/{}/manifests/{}",
-                self.config
-                    .protocol
-                    .scheme_for(reference.resolve_registry()),
-                reference.resolve_registry(),
-                reference.repository(),
-                digest,
-            )
-        } else {
-            format!(
-                "{}://{}/v2/{}/manifests/{}",
-                self.config
-                    .protocol
-                    .scheme_for(reference.resolve_registry()),
-                reference.resolve_registry(),
-                reference.repository(),
+        let registry = reference.resolve_registry();
+        format!(
+            "{scheme}://{registry}/v2/{repository}/manifests/{reference}{ns}",
+            scheme = self.config.protocol.scheme_for(registry),
+            repository = reference.repository(),
+            reference = if let Some(digest) = reference.digest() {
+                digest
+            } else {
                 reference.tag().unwrap_or("latest")
-            )
-        }
+            },
+            ns = reference
+                .namespace()
+                .map(|ns| format!("?ns={ns}"))
+                .unwrap_or_default(),
+        )
     }
 
     /// Convert a Reference to a v2 blob (layer) URL.
-    fn to_v2_blob_url(&self, registry: &str, repository: &str, digest: &str) -> String {
+    fn to_v2_blob_url(&self, reference: &Reference, digest: &str) -> String {
+        let registry = reference.resolve_registry();
         format!(
-            "{}://{}/v2/{}/blobs/{}",
-            self.config.protocol.scheme_for(registry),
-            registry,
-            repository,
-            digest,
+            "{scheme}://{registry}/v2/{repository}/blobs/{digest}{ns}",
+            scheme = self.config.protocol.scheme_for(registry),
+            repository = reference.repository(),
+            ns = reference
+                .namespace()
+                .map(|ns| format!("?ns={ns}"))
+                .unwrap_or_default(),
         )
     }
 
     /// Convert a Reference to a v2 blob upload URL.
     fn to_v2_blob_upload_url(&self, reference: &Reference) -> String {
-        self.to_v2_blob_url(
-            reference.resolve_registry(),
-            reference.repository(),
-            "uploads/",
-        )
+        self.to_v2_blob_url(reference, "uploads/")
     }
 
     fn to_list_tags_url(&self, reference: &Reference) -> String {
+        let registry = reference.resolve_registry();
         format!(
-            "{}://{}/v2/{}/tags/list",
-            self.config
-                .protocol
-                .scheme_for(reference.resolve_registry()),
-            reference.resolve_registry(),
-            reference.repository(),
+            "{scheme}://{registry}/v2/{repository}/tags/list{ns}",
+            scheme = self.config.protocol.scheme_for(registry),
+            repository = reference.repository(),
+            ns = reference
+                .namespace()
+                .map(|ns| format!("?ns={ns}"))
+                .unwrap_or_default(),
         )
     }
 }
@@ -1941,6 +1935,7 @@ fn digest_header_value(headers: HeaderMap, body: Option<&[u8]>) -> Result<String
 mod test {
     use super::*;
     use crate::manifest::{self, IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE};
+    use rstest::rstest;
     use std::convert::TryFrom;
     use std::fs;
     use std::path;
@@ -2075,31 +2070,34 @@ mod test {
 
     #[test]
     fn test_to_v2_blob_url() {
-        let image = Reference::try_from(HELLO_IMAGE_TAG).expect("failed to parse reference");
-        let blob_url = Client::default().to_v2_blob_url(
-            image.registry(),
-            image.repository(),
-            "sha256:deadbeef",
-        );
-        assert_eq!(
-            blob_url,
-            "https://webassembly.azurecr.io/v2/hello-wasm/blobs/sha256:deadbeef"
-        )
-    }
-
-    #[test]
-    fn test_to_v2_manifest() {
+        let mut image = Reference::try_from(HELLO_IMAGE_TAG).expect("failed to parse reference");
         let c = Client::default();
 
-        for &(image, expected_uri) in [
-            (HELLO_IMAGE_NO_TAG, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/latest"), // TODO: confirm this is the right translation when no tag
-            (HELLO_IMAGE_TAG, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/v1"),
-            (HELLO_IMAGE_DIGEST, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7"),
-            (HELLO_IMAGE_TAG_AND_DIGEST, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7"),
-            ].iter() {
-                let reference = Reference::try_from(image).expect("failed to parse reference");
-                assert_eq!(c.to_v2_manifest_url(&reference), expected_uri);
-            }
+        assert_eq!(
+            c.to_v2_blob_url(&image, "sha256:deadbeef"),
+            "https://webassembly.azurecr.io/v2/hello-wasm/blobs/sha256:deadbeef"
+        );
+
+        image.set_mirror_registry("docker.mirror.io".to_owned());
+        assert_eq!(
+            c.to_v2_blob_url(&image, "sha256:deadbeef"),
+            "https://docker.mirror.io/v2/hello-wasm/blobs/sha256:deadbeef?ns=webassembly.azurecr.io"
+        );
+    }
+
+    #[rstest(image, expected_uri, expected_mirror_uri,
+        case(HELLO_IMAGE_NO_TAG, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/latest", "https://docker.mirror.io/v2/hello-wasm/manifests/latest?ns=webassembly.azurecr.io"), // TODO: confirm this is the right translation when no tag
+        case(HELLO_IMAGE_TAG, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/v1", "https://docker.mirror.io/v2/hello-wasm/manifests/v1?ns=webassembly.azurecr.io"),
+        case(HELLO_IMAGE_DIGEST, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7", "https://docker.mirror.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7?ns=webassembly.azurecr.io"),
+        case(HELLO_IMAGE_TAG_AND_DIGEST, "https://webassembly.azurecr.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7", "https://docker.mirror.io/v2/hello-wasm/manifests/sha256:51d9b231d5129e3ffc267c9d455c49d789bf3167b611a07ab6e4b3304c96b0e7?ns=webassembly.azurecr.io"),
+    )]
+    fn test_to_v2_manifest(image: &str, expected_uri: &str, expected_mirror_uri: &str) {
+        let mut reference = Reference::try_from(image).expect("failed to parse reference");
+        let c = Client::default();
+        assert_eq!(c.to_v2_manifest_url(&reference), expected_uri);
+
+        reference.set_mirror_registry("docker.mirror.io".to_owned());
+        assert_eq!(c.to_v2_manifest_url(&reference), expected_mirror_uri);
     }
 
     #[test]
@@ -2115,13 +2113,19 @@ mod test {
 
     #[test]
     fn test_to_list_tags_url() {
-        let image = Reference::try_from(HELLO_IMAGE_TAG).expect("failed to parse reference");
-        let blob_url = Client::default().to_list_tags_url(&image);
+        let mut image = Reference::try_from(HELLO_IMAGE_TAG).expect("failed to parse reference");
+        let c = Client::default();
 
         assert_eq!(
-            blob_url,
+            c.to_list_tags_url(&image),
             "https://webassembly.azurecr.io/v2/hello-wasm/tags/list"
-        )
+        );
+
+        image.set_mirror_registry("docker.mirror.io".to_owned());
+        assert_eq!(
+            c.to_list_tags_url(&image),
+            "https://docker.mirror.io/v2/hello-wasm/tags/list?ns=webassembly.azurecr.io"
+        );
     }
 
     #[test]
@@ -2148,11 +2152,7 @@ mod test {
             .expect("Could not parse reference");
         assert_eq!(
             "http://webassembly.azurecr.io/v2/hello/blobs/sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            c.to_v2_blob_url(
-                reference.registry(),
-                reference.repository(),
-                reference.digest().unwrap()
-            )
+            c.to_v2_blob_url(&reference, reference.digest().unwrap())
         );
     }
 
@@ -2200,11 +2200,7 @@ mod test {
             .expect("Could not parse reference");
         assert_eq!(
             "https://webassembly.azurecr.io/v2/hello/blobs/sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            c.to_v2_blob_url(
-                reference.registry(),
-                reference.repository(),
-                reference.digest().unwrap()
-            )
+            c.to_v2_blob_url(&reference, reference.digest().unwrap())
         );
     }
 
@@ -2220,11 +2216,7 @@ mod test {
             .expect("Could not parse reference");
         assert_eq!(
             "http://oci.registry.local/v2/hello/blobs/sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            c.to_v2_blob_url(
-                reference.registry(),
-                reference.repository(),
-                reference.digest().unwrap()
-            )
+            c.to_v2_blob_url(&reference, reference.digest().unwrap())
         );
     }
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -104,6 +104,17 @@ impl Reference {
         }
     }
 
+    /// Clone the Reference for the same image with a new digest.
+    pub fn clone_with_digest(&self, digest: String) -> Self {
+        Self {
+            registry: self.registry.clone(),
+            mirror_registry: self.mirror_registry.clone(),
+            repository: self.repository.clone(),
+            tag: None,
+            digest: Some(digest),
+        }
+    }
+
     /// Set a pull mirror registry for this reference.
     ///
     /// The mirror registry will be used to resolve the image, the original registry

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -75,6 +75,7 @@ impl Error for ParseError {}
 #[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub struct Reference {
     registry: String,
+    mirror_registry: Option<String>,
     repository: String,
     tag: Option<String>,
     digest: Option<String>,
@@ -85,6 +86,7 @@ impl Reference {
     pub fn with_tag(registry: String, repository: String, tag: String) -> Self {
         Self {
             registry,
+            mirror_registry: None,
             repository,
             tag: Some(tag),
             digest: None,
@@ -95,45 +97,78 @@ impl Reference {
     pub fn with_digest(registry: String, repository: String, digest: String) -> Self {
         Self {
             registry,
+            mirror_registry: None,
             repository,
             tag: None,
             digest: Some(digest),
         }
     }
 
+    /// Set a pull mirror registry for this reference.
+    ///
+    /// The mirror registry will be used to resolve the image, the original registry
+    /// is available via the [`Reference::namespace`] function.
+    ///
+    /// The original registry will be sent with the `ns` query parameter to the mirror registry.
+    /// The `ns` query parameter is currently not part of the stable OCI Distribution Spec yet,
+    /// but is being discussed to be added and is already used by some other implementations
+    /// (for example containerd). So be aware that this feature might not work with all registries.
+    ///
+    /// Since this is not part of the stable OCI Distribution Spec yet, this feature is exempt from
+    /// semver backwards compatibility guarantees and might change in the future.
+    #[doc(hidden)]
+    pub fn set_mirror_registry(&mut self, registry: String) {
+        self.mirror_registry = Some(registry);
+    }
+
     /// Resolve the registry address of a given `Reference`.
     ///
     /// Some registries, such as docker.io, uses a different address for the actual
     /// registry. This function implements such redirection.
+    ///
+    /// If a mirror registry is set, it will be used instead of the original registry.
     pub fn resolve_registry(&self) -> &str {
-        let registry = self.registry();
-        match registry {
-            "docker.io" => "index.docker.io",
-            _ => registry,
+        match (self.registry(), self.mirror_registry.as_deref()) {
+            (_, Some(mirror_registry)) => mirror_registry,
+            ("docker.io", None) => "index.docker.io",
+            (registry, None) => registry,
         }
     }
 
-    /// registry returns the name of the registry.
+    /// Returns the name of the registry.
     pub fn registry(&self) -> &str {
         &self.registry
     }
 
-    /// repository returns the name of the repository.
+    /// Returns the name of the repository.
     pub fn repository(&self) -> &str {
         &self.repository
     }
 
-    /// tag returns the object's tag, if present.
+    /// Returns the object's tag, if present.
     pub fn tag(&self) -> Option<&str> {
         self.tag.as_deref()
     }
 
-    /// digest returns the object's digest, if present.
+    /// Returns the object's digest, if present.
     pub fn digest(&self) -> Option<&str> {
         self.digest.as_deref()
     }
 
-    /// full_name returns the full repository name and path.
+    /// Returns the original registry when pulled via a mirror.
+    ///
+    /// Since this is not part of the stable OCI Distribution Spec yet, this feature is exempt from
+    /// semver backwards compatibility guarantees and might change in the future.
+    #[doc(hidden)]
+    pub fn namespace(&self) -> Option<&str> {
+        if self.mirror_registry.is_some() {
+            Some(self.registry())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the full repository name and path.
     fn full_name(&self) -> String {
         if self.registry() == "" {
             self.repository().to_string()
@@ -142,7 +177,7 @@ impl Reference {
         }
     }
 
-    /// whole returns the whole reference.
+    /// Returns the whole reference.
     pub fn whole(&self) -> String {
         let mut s = self.full_name();
         if let Some(t) = self.tag() {
@@ -200,6 +235,7 @@ impl TryFrom<String> for Reference {
         let (registry, repository) = split_domain(name);
         let reference = Reference {
             registry,
+            mirror_registry: None,
             repository,
             tag,
             digest,
@@ -355,6 +391,46 @@ mod test {
         )]
         fn parse_bad_reference(input: &str, err: ParseError) {
             assert_eq!(Reference::try_from(input).unwrap_err(), err)
+        }
+
+        #[rstest(
+            input,
+            registry,
+            resolved_registry,
+            whole,
+            case(
+                "busybox",
+                "docker.io",
+                "index.docker.io",
+                "docker.io/library/busybox:latest"
+            ),
+            case("test.com/repo:tag", "test.com", "test.com", "test.com/repo:tag"),
+            case("test:5000/repo", "test:5000", "test:5000", "test:5000/repo:latest"),
+            case(
+                "sub-dom1.foo.com/bar/baz/quux",
+                "sub-dom1.foo.com",
+                "sub-dom1.foo.com",
+                "sub-dom1.foo.com/bar/baz/quux:latest"
+            ),
+            case(
+                "b.gcr.io/test.example.com/my-app:test.example.com",
+                "b.gcr.io",
+                "b.gcr.io",
+                "b.gcr.io/test.example.com/my-app:test.example.com"
+            )
+        )]
+        fn test_mirror_registry(input: &str, registry: &str, resolved_registry: &str, whole: &str) {
+            let mut reference = Reference::try_from(input).expect("could not parse reference");
+            assert_eq!(resolved_registry, reference.resolve_registry());
+            assert_eq!(registry, reference.registry());
+            assert_eq!(None, reference.namespace());
+            assert_eq!(whole, reference.whole());
+
+            reference.set_mirror_registry("docker.mirror.io".to_owned());
+            assert_eq!("docker.mirror.io", reference.resolve_registry());
+            assert_eq!(registry, reference.registry());
+            assert_eq!(Some(registry), reference.namespace());
+            assert_eq!(whole, reference.whole());
         }
     }
 }


### PR DESCRIPTION
This adds the ability to set a mirror to the `Reference` instance, which is then used to pull the image, instead of the registry that was parsed from the image name. And it then forwards the original registry with the `ns` query parameter to the mirror registry, so the mirror registry can use this information to decide from which registry you wanted to pull something.

This is currently not an officially documented standard feature yet, but it's probably going to be eventually, it's just taking a really long time (https://github.com/opencontainers/distribution-spec/pull/66). But containerd is already using the `ns` query parameter and I think I read somewhere that nexus is also already using the parameter when used as pull through cache (but I haven't verified that). But I think it's a really useful feature (when working with mirrors/proxies), even if it's not officially part of the spec yet, so I also implemented it to the library here.

Some additional notes:
* It currently doesn't really handling pushing after you set the mirror registry (as it would also try to push through the mirror, which probably wouldn't work). But my assumption was, that somebody who set the mirror registry doesn't also use the same `Reference` instance also for pushing the same image again (would that even make sense if you just pulled it). So I decided to not add additional complexity for that use-case in the code for now. For people who don't set a mirror registry, everything works the same as before and pushing works. And if it's really needed, this logic can always be added later, but I wanted to keep the code simpler. But I'm open to feedback.
* I wasn't sure if I should make the parameter for the `set_mirror_registry()` function an `Option<String>`, so you can also unset the mirror again, but for my use-case I don't need it to be unset. But let me know what you think and I can change it.
* I have no idea why `cargo fmt` formats the `rstest` at the `test_mirror_registry` like that, but doesn't do it for the other tests :man_shrugging: 

Also: The last commit doesn't have anything to do with this feature, but when scrolling through the code while adding this feature, I saw the `FIXME` and thought "why not just fix that as well?" :smiley: