### PR TITLE
feat(client): Make store_auth_if_needed public

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -374,7 +374,15 @@ impl Client {
         self.auth_store.read().await.contains_key(registry)
     }
 
-    async fn store_auth_if_needed(&self, registry: &str, auth: &RegistryAuth) {
+    /// Store the authentication information for this registry if it's not already stored in the client.
+    ///
+    /// Most of the time, you don't need to call this method directly. It's called by other
+    /// methods (where you have to provide the authentication information as parameter).
+    ///
+    /// But if you want to pull/push a blob without calling any of the other methods first, which would
+    /// store the authentication information, you can call this method to store the authentication
+    /// information manually.
+    pub async fn store_auth_if_needed(&self, registry: &str, auth: &RegistryAuth) {
         if !self.is_stored_auth(registry).await {
             self.store_auth(registry, auth.clone()).await;
         }


### PR DESCRIPTION
This allows to store auth information to the client if needed, without doing a full auth request.

I have the use-case where I might pull a blob without pulling the manifest before, as there are multiple replicas and the manifest might have been pulled by another instance already. But that means that some instances never had the auth information stored and therefore the pull of the blob fails with a 401.

I know I could all `client.auth(...)`, but that also runs a full auth request (which even is multiple requests) every time, even if the auth info is already stored for this registry, or even when it's already authenticated for this image.

I also could keep track myself if I already authenticated for a certain registry, but that would be kinda redundant if the client already keeps track of it.

And I understand that you don't want to require to provide auth information as required parameter when pulling a blob, as if you do everything with one instance, it should already know it from pulling the manifest. So I think the best solution is just to make the `store_auth_if_needed(...)` public, so I can do exactly what I need to do, give the auth info to the client so it can use it if required for pulling a blob, without affecting any other use-cases and workflows.