### PR TITLE
fix(blob): Makes sure `SizedStream` impls `Stream`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 name = "oci-client"
 readme = "README.md"
 repository = "https://github.com/oras-project/rust-oci-client"
-version = "0.12.0"
+version = "0.12.1"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -2,6 +2,7 @@
 use std::task::Poll;
 
 use futures_util::stream::{BoxStream, Stream};
+use futures_util::TryStreamExt;
 
 use crate::digest::Digester;
 use crate::errors::DigestError;
@@ -12,6 +13,17 @@ pub struct SizedStream {
     pub content_length: Option<u64>,
     /// The stream of bytes
     pub stream: BoxStream<'static, Result<bytes::Bytes, std::io::Error>>,
+}
+
+impl Stream for SizedStream {
+    type Item = Result<bytes::Bytes, std::io::Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.stream.try_poll_next_unpin(cx)
+    }
 }
 
 /// The response of a partial blob request


### PR DESCRIPTION
This impls a simple passthrough stream implementation for `SizedStream`. It also updates the doc to show how you can use the stream directly. Please note that although this is _technically_ an add by adding the impl Stream, it really just fixes some possibly annoying ergonomics. So I marked this as 0.12.1

Fixes #157