### PR TITLE
Docs.rs badge, update crate name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Formerly known as `oci-distribution`
 
-[![oci-distribution documentation](https://docs.rs/oci-distribution/badge.svg)](https://docs.rs/oci-distribution)
+[![oci-client documentation](https://docs.rs/oci-client/badge.svg)](https://docs.rs/oci-client)
 
 This Rust library implements the
 [OCI Distribution specification](https://github.com/opencontainers/distribution-spec/blob/master/spec.md),


### PR DESCRIPTION
Looks like the crate has been re-published as `oci-client`. This pr updates the docs link in the readme.