### PR TITLE
fix(client): Return the digest header for partial responses

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -11,6 +11,10 @@ use crate::errors::DigestError;
 pub struct SizedStream {
     /// The length of the stream if the upstream registry sent a `Content-Length` header
     pub content_length: Option<u64>,
+    /// The digest header value if the upstream registry sent a `Digest` header. This should be used
+    /// (in addition to the layer digest) for validation when using partial requests as the library
+    /// can't validate against the full response.
+    pub digest_header_value: Option<String>,
     /// The stream of bytes
     pub stream: BoxStream<'static, Result<bytes::Bytes, std::io::Error>>,
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -421,6 +421,7 @@ pub struct Platform {
     /// This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature.
     /// When `os` is `windows`, image indexes SHOULD use, and implementations SHOULD understand the following values:
     /// - `win32k`: image requires `win32k.sys` on the host (Note: `win32k.sys` is missing on Nano Server)
+    ///
     /// When `os` is not `windows`, values are implementation-defined and SHOULD be submitted to this specification for standardization.
     #[serde(rename = "os.features")]
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
In #163 it was pointed out that we can't use validating streams for partial responses, which makes complete sense. Because of this, we need to pass back the digest header for use in validation once a partial download is complete.

This also fixes a few clippy errors I saw