### PR TITLE
Release 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,15 @@ authors = [
   "Flavio Castelli <fcastelli@suse.com>",
 ]
 description = "An OCI implementation in Rust"
+documentation = "https://docs.rs/oci-client"
 edition = "2021"
+homepage = "https://github.com/oras-project/rust-oci-client"
 keywords = ["oci", "containers"]
 license = "Apache-2.0"
 name = "oci-client"
 readme = "README.md"
 repository = "https://github.com/oras-project/rust-oci-client"
-version = "0.12.1"
+version = "0.13.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
I've also updated the `Cargo.toml` metadata to show links to our docs.

## What's Changed

- client: add support to set https_proxy/no_proxy for client by @Xynnn007 in https://github.com/oras-project/rust-oci-client/pull/160
- chore(deps): Update testcontainers requirement from 0.20 to 0.22 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/161
- Docs.rs badge, update crate name. by @bddap in https://github.com/oras-project/rust-oci-client/pull/166
- chore(deps): Bump actions/checkout from 4.1.7 to 4.2.0 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/170
- chore(deps): Update testcontainers requirement from 0.22 to 0.23 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/169
- chore(deps): Update rstest requirement from 0.22.0 to 0.23.0 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/168
- Allow doing start-end RANGE requests against blobs by @thundergolfer in https://github.com/oras-project/rust-oci-client/pull/163
- fix(client): Return the digest header for partial responses by @thomastaylor312 in https://github.com/oras-project/rust-oci-client/pull/171
- remove reference by @flavio in https://github.com/oras-project/rust-oci-client/pull/164

## New Contributors

- @bddap made their first contribution in https://github.com/oras-project/rust-oci-client/pull/166
- @thundergolfer made their first contribution in https://github.com/oras-project/rust-oci-client/pull/163

**Full Changelog**: https://github.com/oras-project/rust-oci-client/compare/v0.12.1...v0.13.0
