### PR TITLE
feat: Relax location_header_to_url path handling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1526,7 +1526,7 @@ impl Client {
         location_header: &reqwest::header::HeaderValue,
     ) -> Result<String> {
         let lh = location_header.to_str()?;
-        if lh.starts_with("/v2/") {
+        if lh.starts_with("/") {
             let registry = image.resolve_registry();
             Ok(format!(
                 "{scheme}://{registry}{lh}",


### PR DESCRIPTION
When testing this library against [Google Cloud Artifact Registry](https://cloud.google.com/artifact-registry/docs), I noticed the upload URL they return when obtaining a session id differs from the spec.

Instead of returning a `Location:` as specified in the OCI Distribution spec:
```
/v2/<name>/blobs/upload/<reference>
```

GCP Artifactory Registry returns the following `Location:` header:
```
/artifacts-uploads/namespaces/<gcp-project-id>/repositories/<artifact-registry-repository>/uploads/<some-hash>
```

I would like to propose relaxing the `location_header_to_url` code slightly to allow the use of this returned header, which does seem based to be on a perhaps slightly "looser interpretation" of [what the spec says under `POST then PUT`](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put):
> Upon success, the response MUST have a code of 202 Accepted, and MUST include the following header:
```
Location: <location>
```
> The <location> MUST contain a UUID representing a unique session ID for the upload to follow. The <location> does not necessarily need to be provided by the registry itself. In fact, offloading to another server can be a [better strategy](https://www.backblaze.com/blog/design-thinking-b2-apis-the-hidden-costs-of-s3-compatibility/).
> 
> Optionally, the location MAY be absolute (containing the protocol and/or hostname), or it MAY be relative (containing just the URL path). For more information, see [RFC 7231](https://tools.ietf.org/html/rfc7231#section-7.1.2).

To further motivate this, 'd like to point out that the [`oras-go`](https://github.com/oras-project/oras-go) handles this without any issue, so it would seem reasonable to try to align the behavior between the two libraries in this regard.