### PR TITLE
fix: Set Content-Length header on monolithic push session request

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1244,6 +1244,7 @@ impl Client {
             .apply_auth(image, RegistryOperation::Push)
             .await?
             .into_request_builder()
+            .header("Content-Length", 0)
             .send()
             .await?;
 


### PR DESCRIPTION
Building on my testing of [Google Cloud Artifact Registry](https://cloud.google.com/artifact-registry/docs) from #175, I noticed that their registry requires `Content-Length` to be set for acquiring a monolithic push session:
```
ServerError {
    code: 411,
    url: "https://<gcp-region>.pkg.dev/v2/<gcp-project-id>/<registry-id>/go-example-provider/blobs/uploads/",
    message: "<!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n  <meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n  <title>Error 411 (Length Required)!!1</title>\n  <style>\n    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n  </style>\n  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n  <p><b>411.</b> <ins>That's an error.</ins>\n  <p>POST requests require a <code>Content-length</code> header.  <ins>That's all we know.</ins>\n"
}
```

I don't see a downside to setting this for monolithic pushes even though it's not required by the OCI Distribution spec.