### PR TITLE
feat: Add option for using monolithic push

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -559,6 +559,10 @@ impl Client {
         data: &[u8],
         digest: &str,
     ) -> Result<String> {
+        if self.config.use_monolithic_push {
+            return self.push_blob_monolithically(image_ref, data, digest).await;
+        }
+
         match self.push_blob_chunked(image_ref, data, digest).await {
             Ok(url) => Ok(url),
             Err(OciDistributionError::SpecViolationError(violation)) => {
@@ -1797,6 +1801,9 @@ pub struct ClientConfig {
     /// Accept invalid certificates. Defaults to false
     pub accept_invalid_certificates: bool,
 
+    /// Use monolithic push for pushing blobs. Defaults to false
+    pub use_monolithic_push: bool,
+
     /// A list of extra root certificate to trust. This can be used to connect
     /// to servers using self-signed certificates
     pub extra_root_certificates: Vec<Certificate>,
@@ -1861,6 +1868,7 @@ impl Default for ClientConfig {
             #[cfg(feature = "native-tls")]
             accept_invalid_hostnames: false,
             accept_invalid_certificates: false,
+            use_monolithic_push: false,
             extra_root_certificates: Vec::new(),
             platform_resolver: Some(Box::new(current_platform_resolver)),
             max_concurrent_upload: DEFAULT_MAX_CONCURRENT_UPLOAD,


### PR DESCRIPTION
Following up on #175 and #176, this rounds out the remaining set of functionality that's needed to use `rust-oci-client` for pushing to GCP Artifact Registry similarly to how `oras-go` can be used for this.

This seemed like an option that should be available for configuring the client in case you're working with a registry that's not fully spec compliant.