### PR TITLE
chore: Updates thiserror and fixes cargo deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ reqwest = { version = "0.12.4", default-features = false, features = [
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
-thiserror = "1.0"
+thiserror = "2"
 tokio = { version = "1.21", features = ["macros", "io-util"] }
 tracing = { version = "0.1", features = ['log'] }
 unicase = "2.6"

--- a/deny.toml
+++ b/deny.toml
@@ -7,23 +7,12 @@ confidence-threshold = 1.0
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = [
-    "Unicode-DFS-2016",
-    "Apache-2.0",
-    "BSD-3-Clause",
-    "ISC",
-    "MIT",
-    "MPL-2.0",
-]
+allow = ["Unicode-3.0", "Apache-2.0", "BSD-3-Clause", "ISC", "MIT", "MPL-2.0"]
 
 exceptions = [
     # Ring has a...complicated license. However, since it is at the core of a large number of rust
     # projects, we are manually allowing the OpenSSL part of the license
     { name = "ring", allow = [
-        "OpenSSL",
-    ] },
-    # same exception as above for another crate
-    { name = "aws-lc-sys", allow = [
         "OpenSSL",
     ] },
 ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1740,7 +1740,7 @@ impl<'a> RequestBuilderWrapper<'a> {
     fn from_client(
         client: &'a Client,
         f: impl Fn(&reqwest::Client) -> RequestBuilder,
-    ) -> RequestBuilderWrapper {
+    ) -> RequestBuilderWrapper<'a> {
         let request_builder = f(&client.client);
         RequestBuilderWrapper {
             client,


### PR DESCRIPTION
This updates our deny.toml to remove unused exceptions and change which unicode license is being allowed. I also fixed a small clippy error that showed up