### PR TITLE
feat: Add blocking client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: engineerd/configurator@v0.0.10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,18 @@ version = "0.14.0"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[[example]]
+name = "blocking-get-manifest"
+path = "examples/blocking-get-manifest/main.rs"
+required-features = ["blocking"]
+
 [features]
-default = ["native-tls", "test-registry"]
+default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 trust-dns = ["reqwest/trust-dns"]
+blocking = ["reqwest/blocking"]
 # This features is used by tests that use docker to create a registry
 test-registry = []
 
@@ -70,6 +76,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3.3"
 # This should stay pinned here until testcontainers makes sure all of its deps using rustls are
 # using the ring feature. Otherwise this fails to compile on Windows
-testcontainers = "0.23"
+testcontainers = { version = "0.23", features = ["blocking"] }
 tokio = { version = "1.21", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/examples/blocking-get-manifest/main.rs
+++ b/examples/blocking-get-manifest/main.rs
@@ -1,0 +1,100 @@
+use oci_client::{blocking::Client, secrets::RegistryAuth, Reference};
+
+use clap::Parser;
+use docker_credential::{CredentialRetrievalError, DockerCredential};
+use tracing::{debug, warn};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{fmt, EnvFilter};
+
+/// Pull a WebAssembly module from a OCI container registry
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub(crate) struct Cli {
+    /// Enable verbose mode
+    #[clap(short, long)]
+    pub verbose: bool,
+
+    /// Perform anonymous operation, by default the tool tries to reuse the docker credentials read
+    /// from the default docker file
+    #[clap(short, long)]
+    pub anonymous: bool,
+
+    /// Pull image from registry using HTTP instead of HTTPS
+    #[clap(short, long)]
+    pub insecure: bool,
+
+    /// Enable json output
+    #[clap(long)]
+    pub json: bool,
+
+    /// Name of the image to pull
+    image: String,
+}
+
+fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
+    let server = reference
+        .resolve_registry()
+        .strip_suffix('/')
+        .unwrap_or_else(|| reference.resolve_registry());
+
+    if cli.anonymous {
+        return RegistryAuth::Anonymous;
+    }
+
+    match docker_credential::get_credential(server) {
+        Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
+        Err(CredentialRetrievalError::NoCredentialConfigured) => RegistryAuth::Anonymous,
+        Err(e) => panic!("Error handling docker configuration file: {}", e),
+        Ok(DockerCredential::UsernamePassword(username, password)) => {
+            debug!("Found docker credentials");
+            RegistryAuth::Basic(username, password)
+        }
+        Ok(DockerCredential::IdentityToken(_)) => {
+            warn!("Cannot use contents of docker config, identity token not supported. Using anonymous auth");
+            RegistryAuth::Anonymous
+        }
+    }
+}
+
+fn build_client_config(cli: &Cli) -> oci_client::blocking::ClientConfig {
+    let protocol = if cli.insecure {
+        oci_client::blocking::ClientProtocol::Http
+    } else {
+        oci_client::blocking::ClientProtocol::Https
+    };
+
+    oci_client::blocking::ClientConfig {
+        protocol,
+        ..Default::default()
+    }
+}
+
+pub fn main() {
+    let cli = Cli::parse();
+
+    // setup logging
+    let level_filter = if cli.verbose { "debug" } else { "info" };
+    let filter_layer = EnvFilter::new(level_filter);
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .init();
+
+    let reference: Reference = cli.image.parse().expect("Not a valid image reference");
+    let auth = build_auth(&reference, &cli);
+
+    let client_config = build_client_config(&cli);
+    let mut client = Client::new(client_config);
+
+    let (manifest, _) = client
+        .pull_manifest(&reference, &auth)
+        .expect("Cannot pull manifest");
+
+    if cli.json {
+        serde_json::to_writer_pretty(std::io::stdout(), &manifest)
+            .expect("Cannot serialize manifest to JSON");
+        println!();
+    } else {
+        println!("{}", manifest);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -4,5 +4,5 @@ build +FLAGS='':
 test:
     cargo fmt --all -- --check
     cargo clippy --workspace
-    cargo test --workspace --lib --tests
+    cargo test --workspace --lib --tests --all-features
     cargo test --doc --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ use sha2::Digest;
 
 pub mod annotations;
 mod blob;
+#[cfg(feature = "blocking")]
+pub mod blocking;
 pub mod client;
 pub mod config;
 pub(crate) mod digest;
@@ -12,9 +14,11 @@ pub mod errors;
 pub mod manifest;
 pub mod secrets;
 mod token_cache;
+mod types;
 
 #[doc(inline)]
 pub use client::Client;
+
 #[doc(inline)]
 pub use oci_spec::distribution::{ParseError, Reference};
 #[doc(inline)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,8 +2,8 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    client::{Config, ImageLayer},
     sha256_digest,
+    types::{Config, ImageLayer},
 };
 
 /// The mediatype for WASM layers.

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -21,3 +21,12 @@ impl Authenticable for reqwest::RequestBuilder {
         }
     }
 }
+#[cfg(feature = "blocking")]
+impl Authenticable for reqwest::blocking::RequestBuilder {
+    fn apply_authentication(self, auth: &RegistryAuth) -> Self {
+        match auth {
+            RegistryAuth::Anonymous => self,
+            RegistryAuth::Basic(username, password) => self.basic_auth(username, Some(password)),
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,198 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::{
+    config::ConfigFile,
+    errors::{OciDistributionError, Result},
+    manifest::{
+        OciDescriptor, OciImageManifest, IMAGE_CONFIG_MEDIA_TYPE, IMAGE_LAYER_GZIP_MEDIA_TYPE,
+        IMAGE_LAYER_MEDIA_TYPE,
+    },
+    sha256_digest,
+};
+
+/// The data for an image or module.
+#[derive(Clone)]
+pub struct ImageData {
+    /// The layers of the image or module.
+    pub layers: Vec<ImageLayer>,
+    /// The digest of the image or module.
+    pub digest: Option<String>,
+    /// The Configuration object of the image or module.
+    pub config: Config,
+    /// The manifest of the image or module.
+    pub manifest: Option<OciImageManifest>,
+}
+
+/// The data returned by an OCI registry after a successful push
+/// operation is completed
+pub struct PushResponse {
+    /// Pullable url for the config
+    pub config_url: String,
+    /// Pullable url for the manifest
+    pub manifest_url: String,
+}
+
+/// The data returned by a successful tags/list Request
+#[derive(Deserialize, Debug)]
+pub struct TagResponse {
+    /// Repository Name
+    pub name: String,
+    /// List of existing Tags
+    pub tags: Vec<String>,
+}
+
+/// Layer descriptor required to pull a layer
+pub struct LayerDescriptor<'a> {
+    /// The digest of the layer
+    pub digest: &'a str,
+    /// Optional list of additional URIs to pull the layer from
+    pub urls: &'a Option<Vec<String>>,
+}
+
+/// A trait for converting any type into a [`LayerDescriptor`]
+pub trait AsLayerDescriptor {
+    /// Convert the type to a LayerDescriptor reference
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_>;
+}
+
+impl<T: AsLayerDescriptor> AsLayerDescriptor for &T {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
+        (*self).as_layer_descriptor()
+    }
+}
+
+impl AsLayerDescriptor for &str {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
+        LayerDescriptor {
+            digest: self,
+            urls: &None,
+        }
+    }
+}
+
+impl AsLayerDescriptor for &OciDescriptor {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
+        LayerDescriptor {
+            digest: &self.digest,
+            urls: &self.urls,
+        }
+    }
+}
+
+impl AsLayerDescriptor for &LayerDescriptor<'_> {
+    fn as_layer_descriptor(&self) -> LayerDescriptor<'_> {
+        LayerDescriptor {
+            digest: self.digest,
+            urls: self.urls,
+        }
+    }
+}
+
+/// The data and media type for an image layer
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ImageLayer {
+    /// The data of this layer
+    pub data: Vec<u8>,
+    /// The media type of this layer
+    pub media_type: String,
+    /// This OPTIONAL property contains arbitrary metadata for this descriptor.
+    /// This OPTIONAL property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)
+    pub annotations: Option<BTreeMap<String, String>>,
+}
+
+impl ImageLayer {
+    /// Constructs a new ImageLayer struct with provided data and media type
+    pub fn new(
+        data: Vec<u8>,
+        media_type: String,
+        annotations: Option<BTreeMap<String, String>>,
+    ) -> Self {
+        ImageLayer {
+            data,
+            media_type,
+            annotations,
+        }
+    }
+
+    /// Constructs a new ImageLayer struct with provided data and
+    /// media type application/vnd.oci.image.layer.v1.tar
+    pub fn oci_v1(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
+        Self::new(data, IMAGE_LAYER_MEDIA_TYPE.to_string(), annotations)
+    }
+    /// Constructs a new ImageLayer struct with provided data and
+    /// media type application/vnd.oci.image.layer.v1.tar+gzip
+    pub fn oci_v1_gzip(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
+        Self::new(data, IMAGE_LAYER_GZIP_MEDIA_TYPE.to_string(), annotations)
+    }
+
+    /// Helper function to compute the sha256 digest of an image layer
+    pub fn sha256_digest(&self) -> String {
+        sha256_digest(&self.data)
+    }
+}
+
+/// The data and media type for a configuration object
+#[derive(Clone)]
+pub struct Config {
+    /// The data of this config object
+    pub data: Vec<u8>,
+    /// The media type of this object
+    pub media_type: String,
+    /// This OPTIONAL property contains arbitrary metadata for this descriptor.
+    /// This OPTIONAL property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)
+    pub annotations: Option<BTreeMap<String, String>>,
+}
+
+impl Config {
+    /// Constructs a new Config struct with provided data and media type
+    pub fn new(
+        data: Vec<u8>,
+        media_type: String,
+        annotations: Option<BTreeMap<String, String>>,
+    ) -> Self {
+        Config {
+            data,
+            media_type,
+            annotations,
+        }
+    }
+
+    /// Constructs a new Config struct with provided data and
+    /// media type application/vnd.oci.image.config.v1+json
+    pub fn oci_v1(data: Vec<u8>, annotations: Option<BTreeMap<String, String>>) -> Self {
+        Self::new(data, IMAGE_CONFIG_MEDIA_TYPE.to_string(), annotations)
+    }
+
+    /// Construct a new Config struct with provided [`ConfigFile`] and
+    /// media type `application/vnd.oci.image.config.v1+json`
+    pub fn oci_v1_from_config_file(
+        config_file: ConfigFile,
+        annotations: Option<BTreeMap<String, String>>,
+    ) -> Result<Self> {
+        let data = serde_json::to_vec(&config_file)?;
+        Ok(Self::new(
+            data,
+            IMAGE_CONFIG_MEDIA_TYPE.to_string(),
+            annotations,
+        ))
+    }
+
+    /// Helper function to compute the sha256 digest of this config object
+    pub fn sha256_digest(&self) -> String {
+        sha256_digest(&self.data)
+    }
+}
+
+impl TryFrom<Config> for ConfigFile {
+    type Error = crate::errors::OciDistributionError;
+
+    fn try_from(config: Config) -> Result<Self> {
+        let config = String::from_utf8(config.data)
+            .map_err(|e| OciDistributionError::ConfigConversionError(e.to_string()))?;
+        let config_file: ConfigFile = serde_json::from_str(&config)
+            .map_err(|e| OciDistributionError::ConfigConversionError(e.to_string()))?;
+        Ok(config_file)
+    }
+}


### PR DESCRIPTION
Uses the reqwuest/blocking feature to add a client that can be used from sync rust. This is gated behind the `blocking` feature.

Removed test-registry from default-features.