### PR TITLE
feat: Direct Bearer Token Authentication

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -659,6 +659,13 @@ impl Client {
             image.resolve_registry()
         );
         debug!(?url);
+
+        if let RegistryAuth::Bearer(token) = authentication {
+            return Ok(Some(RegistryTokenType::Bearer(RegistryToken::Token {
+                token: token.clone(),
+            })));
+        }
+
         let res = self.client.get(&url).send().await?;
         let dist_hdr = match res.headers().get(reqwest::header::WWW_AUTHENTICATE) {
             Some(h) => h,

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -7,6 +7,8 @@ pub enum RegistryAuth {
     Anonymous,
     /// Access the registry using HTTP Basic authentication
     Basic(String, String),
+    /// Access the registry using Bearer token authentication
+    Bearer(String),
 }
 
 pub(crate) trait Authenticable {
@@ -18,6 +20,7 @@ impl Authenticable for reqwest::RequestBuilder {
         match auth {
             RegistryAuth::Anonymous => self,
             RegistryAuth::Basic(username, password) => self.basic_auth(username, Some(password)),
+            RegistryAuth::Bearer(token) => self.bearer_auth(token),
         }
     }
 }


### PR DESCRIPTION
Adds RegistryAuth::Bearer for use of direct bearer token authentication