### PR TITLE
Filter empty DOCKER_DIGEST_HEADER

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -95,7 +95,12 @@ impl Digester {
 pub fn digest_header_value(headers: HeaderMap) -> Result<Option<String>> {
     headers
         .get(DOCKER_DIGEST_HEADER)
-        .map(|hv| hv.to_str().map(|s| s.to_string()))
+        .and_then(|hv| {
+            hv.to_str()
+                // Treat present but empty header as missing
+                .map(|s| (!s.is_empty()).then(|| s.to_string()))
+                .transpose()
+        })
         .transpose()
         .map_err(DigestError::from)
 }


### PR DESCRIPTION
[The spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests) says 

> The Docker-Content-Digest header, if present on the response, returns the canonical digest of the uploaded blob which MAY differ from the provided digest. If the digest does differ, it MAY be the case that the hashing algorithms used do not match. See [Content Digests](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests) [apdx-3](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#appendix) for information on how to detect the hashing algorithm in use. Most clients MAY ignore the value, but if it is used, the client MUST verify the value matches the returned manifest. If the <reference> part of a manifest request is a digest, clients SHOULD verify the returned manifest matches this digest.

Specifically the spec says the header MUST be used if "if present on the response", but it does not define what present means. If present means "the header is simply there", then the current behavior is correct and the server is not spec compliant. However, if it means "the key is there and not empty", then the client needs to be more forgiving than it currently is.

The [Go client](https://github.com/oras-project/oras-go/blob/cb6d75be7dd4a78f25fe9d00c76c0d15c4296da6/registry/remote/repository.go#L1553) seems to take the definition that the header must be present and non-empty. 

Note: I discovered this when working against a [Harbor registry](https://goharbor.io/) using a proxy cache.