### PR TITLE
feat: add HTTP proxy for client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -328,6 +328,15 @@ impl TryFrom<ClientConfig> for Client {
             client_builder = client_builder.proxy(proxy);
         }
 
+        if let Some(proxy_addr) = &config.http_proxy {
+            let no_proxy = config
+                .no_proxy
+                .as_ref()
+                .and_then(|no_proxy| NoProxy::from_string(no_proxy));
+            let proxy = Proxy::http(proxy_addr)?.no_proxy(no_proxy);
+            client_builder = client_builder.proxy(proxy);
+        }
+
         let default_token_expiration_secs = config.default_token_expiration_secs;
         Ok(Self {
             config: Arc::new(config),
@@ -1917,6 +1926,11 @@ pub struct ClientConfig {
     /// This defaults to `None`.
     pub https_proxy: Option<String>,
 
+    /// Set the `HTTP PROXY` used by the client.
+    ///
+    /// This defaults to `None`.
+    pub http_proxy: Option<String>,
+
     /// Set the `NO PROXY` used by the client.
     ///
     /// This defaults to `None`.
@@ -1940,6 +1954,7 @@ impl Default for ClientConfig {
             connect_timeout: None,
             user_agent: DEFAULT_USER_AGENT,
             https_proxy: None,
+            http_proxy: None,
             no_proxy: None,
         }
     }


### PR DESCRIPTION
This commit adds one more configuration for client about proxy, s.t. http_proxy. http_proxy sets the http proxy that the client uses to pull images, while no_proxy will define the remote address that will not be accessed by proxy.

This is useful in a local registry scenario where original pull request is in http.

Typical https_proxy looks like `http://127.0.0.1:5432` no_proxy looks like `127.0.0.1,192.168.1.1`

Note that `client_builder.proxy()` function will add rather than overwrite the proxies to underlying reqwest::Client, thus no side effections upon the https proxy setting.