### PR TITLE
release: prepare 0.15.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "Apache-2.0"
 name = "oci-client"
 readme = "README.md"
 repository = "https://github.com/oras-project/rust-oci-client"
-version = "0.14.0"
+version = "0.15.0"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Prepare new release, fixes https://github.com/oras-project/rust-oci-client/issues/197

## What's Changed

- Add artifactType to OciImageIndex by @rylev in https://github.com/oras-project/rust-oci-client/pull/182
- chore(deps): Bump actions/checkout from 4.2.1 to 4.2.2 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/183
- Add subject to OciImageManifest by @fibonacci1729 in https://github.com/oras-project/rust-oci-client/pull/181
- chore: Updates thiserror and fixes cargo deny by @thomastaylor312 in https://github.com/oras-project/rust-oci-client/pull/185
- chore(deps): Update itertools requirement from 0.13.0 to 0.14.0 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/188
- chore(deps): Update rstest requirement from 0.23.0 to 0.24.0 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/186
- chore(deps): Update axum requirement from 0.7 to 0.8 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/187
- feat: Direct Bearer Token Authentication by @prabhpreet in https://github.com/oras-project/rust-oci-client/pull/191
- chore(deps): Update rstest requirement from 0.24.0 to 0.25.0 by @dependabot in https://github.com/oras-project/rust-oci-client/pull/193
- feat: add HTTP proxy for client by @Xynnn007 in https://github.com/oras-project/rust-oci-client/pull/194
- Improve error message by @aochagavia in https://github.com/oras-project/rust-oci-client/pull/196

## New Contributors

- @fibonacci1729 made their first contribution in https://github.com/oras-project/rust-oci-client/pull/181
- @prabhpreet made their first contribution in https://github.com/oras-project/rust-oci-client/pull/191

**Full Changelog**: https://github.com/oras-project/rust-oci-client/compare/v0.14.0...v0.15.0
