### PR TITLE
add push blob async stream support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,8 +5,8 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures_util::future;
 use futures_util::stream::{self, BoxStream, StreamExt, TryStreamExt};
+use futures_util::{future, Stream};
 use http::header::RANGE;
 use http::{HeaderValue, StatusCode};
 use http_auth::{parser::ChallengeParser, ChallengeRef};
@@ -636,9 +636,35 @@ impl Client {
         let mut location = self.begin_push_chunked_session(image).await?;
         let mut start: usize = 0;
         loop {
-            (location, start) = self.push_chunk(&location, image, blob_data, start).await?;
+            (location, start) = self
+                .push_chunk(&location, image, &blob_data[start..], start)
+                .await?;
             if start >= blob_data.len() {
                 break;
+            }
+        }
+        self.end_push_chunked_session(&location, image, blob_digest)
+            .await
+    }
+
+    /// Pushes a blob to the registry as a series of chunks from an input stream
+    ///
+    /// Returns the pullable location of the blob
+    pub async fn push_blob_stream<T: Stream<Item = Result<bytes::Bytes>> + Unpin>(
+        &self,
+        image: &Reference,
+        mut blob_data_stream: T,
+        blob_digest: &str,
+    ) -> Result<String> {
+        let mut location = self.begin_push_chunked_session(image).await?;
+        let mut range_start = 0;
+
+        while let Some(blob_data) = blob_data_stream.next().await {
+            // Make sure we respect the max chunk size
+            for chunk in blob_data?.chunks(self.push_chunk_size) {
+                (location, range_start) = self
+                    .push_chunk(&location, image, chunk, range_start)
+                    .await?;
             }
         }
         self.end_push_chunked_session(&location, image, blob_digest)
@@ -1387,35 +1413,38 @@ impl Client {
     /// Pushes a single chunk of a blob to a registry,
     /// as part of a chunked blob upload.
     ///
-    /// Returns the URL location for the next chunk
+    /// Returns the URL location for the next chunk, alongside the start of the next range to upload
     async fn push_chunk(
         &self,
         location: &str,
         image: &Reference,
         blob_data: &[u8],
-        start_byte: usize,
+        range_start: usize,
     ) -> Result<(String, usize)> {
         if blob_data.is_empty() {
             return Err(OciDistributionError::PushNoDataError);
         };
-        let end_byte = if (start_byte + self.push_chunk_size) < blob_data.len() {
-            start_byte + self.push_chunk_size - 1
-        } else {
-            blob_data.len() - 1
-        };
-        let body = blob_data[start_byte..end_byte + 1].to_vec();
+
+        let range_size = self.push_chunk_size.min(blob_data.len());
+        let end_range_inclusive = range_start + range_size - 1;
+
+        let body = blob_data[..range_size].to_vec();
+
         let mut headers = HeaderMap::new();
         headers.insert(
             "Content-Range",
-            format!("{}-{}", start_byte, end_byte).parse().unwrap(),
+            format!("{}-{}", range_start, end_range_inclusive)
+                .parse()
+                .unwrap(),
         );
+
         headers.insert("Content-Length", format!("{}", body.len()).parse().unwrap());
         headers.insert("Content-Type", "application/octet-stream".parse().unwrap());
 
         debug!(
-            ?start_byte,
-            ?end_byte,
-            blob_data_len = blob_data.len(),
+            ?range_start,
+            ?end_range_inclusive,
+            blob_data_len = body.len(),
             body_len = body.len(),
             ?location,
             ?headers,
@@ -1435,7 +1464,7 @@ impl Client {
         Ok((
             self.extract_location_header(image, res, &reqwest::StatusCode::ACCEPTED)
                 .await?,
-            end_byte + 1,
+            end_range_inclusive + 1,
         ))
     }
 
@@ -2166,6 +2195,7 @@ mod test {
     use std::path;
     use std::result::Result;
 
+    use bytes::Bytes;
     use rstest::rstest;
     use sha2::Digest as _;
     use tempfile::TempDir;
@@ -3481,6 +3511,54 @@ mod test {
             .expect("failed to push empty json blob");
         assert!(client
             .blob_exists(&reference, EMPTY_JSON_DIGEST)
+            .await
+            .expect("failed to check blob existence"));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "test-registry")]
+    async fn test_push_stream() {
+        let real_registry = registry_image_edge()
+            .start()
+            .await
+            .expect("Failed to start registry container");
+
+        let server_port = real_registry
+            .get_host_port_ipv4(5000)
+            .await
+            .expect("Failed to get port");
+
+        let mut client = Client::new(ClientConfig {
+            protocol: ClientProtocol::HttpsExcept(vec![format!("localhost:{}", server_port)]),
+            ..Default::default()
+        });
+        client.push_chunk_size = 253;
+
+        // hash for a byte array counting 16 times from 0 to 255 ([0, 1. 2...., 255] * 16)
+        let data_hash = "sha256:c8f5d0341d54d951a71b136e6e2afcb14d11ed8489a7ae126a8fee0df6ecf193";
+        let data_stream = |repeat| {
+            futures_util::stream::repeat(Bytes::from_iter(0..=255))
+                .take(repeat)
+                .map(Ok)
+        };
+
+        let reference = Reference::try_from(format!("localhost:{}/test-push-stream", server_port))
+            .expect("failed to parse reference");
+
+        // Sanity check: verify that the server rejects the push if the blob has a mismatched digest
+        client
+            .push_blob_stream(&reference, data_stream(1), data_hash)
+            .await
+            .expect_err("expected push to fail with mismatched digest");
+
+        // Now push the stream with the correct digest
+        client
+            .push_blob_stream(&reference, data_stream(16), data_hash)
+            .await
+            .expect("failed to push stream");
+
+        assert!(client
+            .blob_exists(&reference, data_hash)
             .await
             .expect("failed to check blob existence"));
     }


### PR DESCRIPTION
Good morning/afternoon!

This is an attempt at upstream some of the changes I've been carrying for this crate!

This adds a `push_blob_stream` method to the client that takes a stream as input. It's pretty much the same code as the chunked push method, except it just takes data until there's none left. Its signature is such that one can just use the stream from the streaming pull blob method.

It also adds a method that verifies if a blob exists. Combined with the streaming push method, it's quite handy to easily copy a bunch of blobs between two repositories.

Let me know if you see a need to split this into two pull requests or anything else.

I'll add an example and maybe a test if it's required! 