### PR TITLE
refactor(client)!: Reduces allocations of streaming data

### DIFF
--- a/examples/get-manifest/main.rs
+++ b/examples/get-manifest/main.rs
@@ -44,7 +44,7 @@ fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
     match docker_credential::get_credential(server) {
         Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
         Err(CredentialRetrievalError::NoCredentialConfigured) => RegistryAuth::Anonymous,
-        Err(e) => panic!("Error handling docker configuration file: {}", e),
+        Err(e) => panic!("Error handling docker configuration file: {e}"),
         Ok(DockerCredential::UsernamePassword(username, password)) => {
             debug!(username, "Found docker credentials");
             RegistryAuth::Basic(username, password)
@@ -97,6 +97,6 @@ pub async fn main() {
             .expect("Cannot serialize manifest to JSON");
         println!();
     } else {
-        println!("{}", manifest);
+        println!("{manifest}");
     }
 }

--- a/examples/wasm/main.rs
+++ b/examples/wasm/main.rs
@@ -29,7 +29,7 @@ fn build_auth(reference: &Reference, cli: &Cli) -> RegistryAuth {
     match docker_credential::get_credential(server) {
         Err(CredentialRetrievalError::ConfigNotFound) => RegistryAuth::Anonymous,
         Err(CredentialRetrievalError::NoCredentialConfigured) => RegistryAuth::Anonymous,
-        Err(e) => panic!("Error handling docker configuration file: {}", e),
+        Err(e) => panic!("Error handling docker configuration file: {e}"),
         Ok(DockerCredential::UsernamePassword(username, password)) => {
             debug!("Found docker credentials");
             RegistryAuth::Basic(username, password)

--- a/examples/wasm/pull.rs
+++ b/examples/wasm/pull.rs
@@ -22,5 +22,5 @@ pub(crate) async fn pull_wasm(
     async_std::fs::write(output, image_content)
         .await
         .expect("Cannot write to file");
-    println!("Wasm module successfully written to {}", output);
+    println!("Wasm module successfully written to {output}");
 }

--- a/examples/wasm/push.rs
+++ b/examples/wasm/push.rs
@@ -27,7 +27,7 @@ pub(crate) async fn push_wasm(
     )];
 
     let config = Config {
-        data: b"{}".to_vec(),
+        data: bytes::Bytes::from_static(b"{}"),
         media_type: manifest::WASM_CONFIG_MEDIA_TYPE.to_string(),
         annotations: None,
     };
@@ -40,5 +40,5 @@ pub(crate) async fn push_wasm(
         .map(|push_response| push_response.manifest_url)
         .expect("Cannot push Wasm module");
 
-    println!("Wasm module successfully pushed {:?}", response);
+    println!("Wasm module successfully pushed {response:?}");
 }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -85,8 +85,7 @@ impl Stream for VerifyingStream {
                         // Check the header digester and then the layer digester before returning
                         let digest = digester.finalize();
                         if digest != *expected {
-                            return Poll::Ready(Some(Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
+                            return Poll::Ready(Some(Err(std::io::Error::other(
                                 DigestError::VerificationError {
                                     expected: expected.clone(),
                                     actual: digest,
@@ -97,8 +96,7 @@ impl Stream for VerifyingStream {
                         if digest == this.expected_layer_digest {
                             Poll::Ready(None)
                         } else {
-                            Poll::Ready(Some(Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
+                            Poll::Ready(Some(Err(std::io::Error::other(
                                 DigestError::VerificationError {
                                     expected: expected.clone(),
                                     actual: digest,
@@ -111,8 +109,7 @@ impl Stream for VerifyingStream {
                         if digest == this.expected_layer_digest {
                             Poll::Ready(None)
                         } else {
-                            Poll::Ready(Some(Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
+                            Poll::Ready(Some(Err(std::io::Error::other(
                                 DigestError::VerificationError {
                                     expected: this.expected_layer_digest.clone(),
                                     actual: digest,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -42,6 +42,7 @@ pub const IMAGE_LAYER_NONDISTRIBUTABLE_GZIP_MEDIA_TYPE: &str =
 /// An image, or image index, OCI manifest
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum OciManifest {
     /// An OCI image manifest
     Image(OciImageManifest),
@@ -188,8 +189,8 @@ impl From<OciImageManifest> for OciManifest {
 impl std::fmt::Display for OciManifest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OciManifest::Image(oci_image_manifest) => write!(f, "{}", oci_image_manifest),
-            OciManifest::ImageIndex(oci_image_index) => write!(f, "{}", oci_image_index),
+            OciManifest::Image(oci_image_manifest) => write!(f, "{oci_image_manifest}"),
+            OciManifest::ImageIndex(oci_image_index) => write!(f, "{oci_image_index}"),
         }
     }
 }

--- a/tests/digest_validation.rs
+++ b/tests/digest_validation.rs
@@ -127,7 +127,7 @@ impl BadServer {
         let listener = TcpListener::bind(addr).await.unwrap();
         let server_addr = listener.local_addr().unwrap();
         let port = server_addr.port();
-        let server = format!("127.0.0.1:{}", port);
+        let server = format!("127.0.0.1:{port}");
         let handle = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });


### PR DESCRIPTION
This is a breaking change, but modifies the API so anything that would be chunks of data we send (so blobs and the config data) is now a `Bytes`. That means any cloning of data is in the user's hands as they control how they construct the `Bytes`. We only clone bytes, which is cheap and doesn't clone the underlying data. The one exception that I didn't change to `Bytes` is `pull_manifest_raw` that returns a `Vec<u8>` since that is often handled in memory anyway. For consistency, we can change that to return `Bytes` as well if we'd like

Also includes some clippy fixes that will start erroring in the latest version of rust

This is followup to discussion we had in #204