### PR TITLE
chore: replace jwt with jsonwebtoken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { version = "0.4.23", features = ["serde"] }
 futures-util = "0.3"
 http = "1.1"
 http-auth = { version = "0.1", default-features = false }
-jwt = "0.16"
+jsonwebtoken = "9.3"
 lazy_static = "1.4"
 oci-spec = "0.8.1"
 olpc-cjson = "0.1"

--- a/src/token_cache.rs
+++ b/src/token_cache.rs
@@ -101,53 +101,9 @@ impl TokenCache {
         let expiration = match token {
             RegistryTokenType::Basic(_, _) => u64::MAX,
             RegistryTokenType::Bearer(ref t) => {
-                let token_str = t.token();
-
-                // This might be able to change if/when jsonwebtoken provides a simpler API for
-                // looking through jwt claims without validating the token.
-                // See the following GitHub issue for more details:
-                // https://github.com/Keats/jsonwebtoken/issues/401
-                let mut validation = jsonwebtoken::Validation::default();
-                validation.insecure_disable_signature_validation();
-                validation.required_spec_claims.clear();
-                validation.validate_aud = false;
-                validation.validate_exp = false;
-                validation.validate_nbf = false;
-
-                match jsonwebtoken::decode::<BearerTokenClaims>(
-                    token_str,
-                    &jsonwebtoken::DecodingKey::from_secret(&[]),
-                    &validation,
-                ) {
-                    Ok(token) => {
-                        let token_exp = match token.claims.exp {
-                            Some(exp) => exp,
-                            None => {
-                                // the token doesn't have a claim that states a
-                                // value for the expiration. We assume it has a 60
-                                // seconds validity as indicated here:
-                                // https://docs.docker.com/reference/api/registry/auth/#token-response-fields
-                                // > (Optional) The duration in seconds since the token was issued
-                                // > that it will remain valid. When omitted, this defaults to 60 seconds.
-                                // > For compatibility with older clients, a token should never be returned
-                                // > with less than 60 seconds to live.
-                                let now = SystemTime::now();
-                                let epoch = now
-                                    .duration_since(UNIX_EPOCH)
-                                    .expect("Time went backwards")
-                                    .as_secs();
-                                let expiration = epoch + self.default_expiration_secs as u64;
-                                debug!(?token, "Cannot extract expiration from token's claims, assuming a {} seconds validity", self.default_expiration_secs);
-                                expiration
-                            }
-                        };
-
-                        token_exp
-                    }
-                    Err(error) => {
-                        warn!(?error, "Invalid bearer token");
-                        return;
-                    }
+                match parse_expiration_from_jwt(t.token(), self.default_expiration_secs) {
+                    Some(value) => value,
+                    None => return,
                 }
             }
         };
@@ -198,6 +154,55 @@ impl TokenCache {
                 debug!(%key.registry, %key.repository, ?key.operation, miss = true, "Fetching token");
                 None
             }
+        }
+    }
+}
+
+fn parse_expiration_from_jwt(token_str: &str, default_expiration_secs: usize) -> Option<u64> {
+    // This might be able to change if/when jsonwebtoken provides a simpler API for
+    // looking through jwt claims without validating the token.
+    // See the following GitHub issue for more details:
+    // https://github.com/Keats/jsonwebtoken/issues/401
+    let mut validation = jsonwebtoken::Validation::default();
+    validation.insecure_disable_signature_validation();
+    validation.required_spec_claims.clear();
+    validation.validate_aud = false;
+    validation.validate_exp = false;
+    validation.validate_nbf = false;
+
+    match jsonwebtoken::decode::<BearerTokenClaims>(
+        token_str,
+        &jsonwebtoken::DecodingKey::from_secret(&[]),
+        &validation,
+    ) {
+        Ok(token) => {
+            let token_exp = match token.claims.exp {
+                Some(exp) => exp,
+                None => {
+                    // the token doesn't have a claim that states a
+                    // value for the expiration. We assume it has a 60
+                    // seconds validity as indicated here:
+                    // https://docs.docker.com/reference/api/registry/auth/#token-response-fields
+                    // > (Optional) The duration in seconds since the token was issued
+                    // > that it will remain valid. When omitted, this defaults to 60 seconds.
+                    // > For compatibility with older clients, a token should never be returned
+                    // > with less than 60 seconds to live.
+                    let now = SystemTime::now();
+                    let epoch = now
+                        .duration_since(UNIX_EPOCH)
+                        .expect("Time went backwards")
+                        .as_secs();
+                    let expiration = epoch + default_expiration_secs as u64;
+                    debug!(?token, "Cannot extract expiration from token's claims, assuming a {} seconds validity", default_expiration_secs);
+                    expiration
+                }
+            };
+
+            Some(token_exp)
+        }
+        Err(error) => {
+            warn!(?error, "Invalid bearer token");
+            None
         }
     }
 }


### PR DESCRIPTION
https://github.com/oras-project/rust-oci-client/issues/167 suggests moving away from `jwt` because it's not actively maintained. These changes replace `jwt` with `jsonwebtoken`.