### PR TITLE
feat: add rustls-tls-no-provider feature for BYO crypto provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ maintenance = { status = "actively-developed" }
 default = ["rustls-tls", "test-registry"]
 native-tls = ["reqwest/native-tls", "jsonwebtoken/rust_crypto"]
 rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]
+# Like `rustls-tls` but without a bundled crypto provider: the consumer
+# installs their own rustls `CryptoProvider` (e.g. ring) and avoids the
+# aws-lc-rs C/cmake build. Mirrors reqwest's own `rustls-no-provider`.
+rustls-tls-no-provider = ["reqwest/rustls-no-provider", "jsonwebtoken/rust_crypto"]
 hickory-dns = ["reqwest/hickory-dns"]
 # This features is used by tests that use docker to create a registry
 test-registry = []


### PR DESCRIPTION
### Problem

`oci-client`'s only rustls option, `rustls-tls`, hardcodes the **aws-lc-rs** crypto provider through *both* `reqwest/rustls` and `jsonwebtoken/aws_lc_rs`. Downstreams that standardize on the **ring** provider — to avoid aws-lc-rs's C/cmake build toolchain — have no path: Cargo feature unification is additive, so a workspace-level `rustls/ring` pin cannot remove the aws-lc-rs that these features force on.

### Change

Add `rustls-tls-no-provider`, mirroring reqwest's own `rustls-no-provider`: it wires `reqwest/rustls-no-provider` + `jsonwebtoken/rust_crypto` and leaves the rustls `CryptoProvider` for the consumer to install (e.g. `rustls::crypto::ring::default_provider().install_default()`).

No new dependencies — `rust_crypto` is the same `jsonwebtoken` backend the existing `native-tls` feature already uses. The default `rustls-tls` is unchanged, so there's no behavior change for existing users.

### Verification

```
$ cargo tree --no-default-features --features rustls-tls-no-provider -i aws-lc-rs
# (empty — aws-lc-rs is not in the tree)

$ cargo build --no-default-features --features rustls-tls-no-provider
# builds clean
```

For contrast, the default `rustls-tls` still pulls `aws-lc-rs` as before.

Happy to wire the new feature into the CI feature matrix if you point me at where it lives.
