### PR TITLE
feat: Enabled native-tls feature to use newly introduced json-webtoken-openssl as a cryptoprovider dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["rustls-tls", "test-registry"]
-native-tls = ["reqwest/native-tls", "jsonwebtoken/rust_crypto"]
+native-tls = ["reqwest/native-tls", "dep:jsonwebtoken-openssl"]
 rustls-tls = ["reqwest/rustls", "jsonwebtoken/aws_lc_rs"]
 hickory-dns = ["reqwest/hickory-dns"]
 # This features is used by tests that use docker to create a registry
@@ -57,6 +57,9 @@ tokio = { version = "1", features = ["macros", "io-util"] }
 tracing = { version = "0.1", features = ['log'] }
 unicase = "2.8"
 
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
+jsonwebtoken-openssl = { version = "1.0", optional = true }
+
 [dev-dependencies]
 assert-json-diff = "2.0"
 anyhow = "1"
@@ -65,7 +68,6 @@ clap = { version = "4.5", features = ["derive"] }
 rstest = "0.26"
 docker_credential = "1.3"
 hmac = "0.13"
-jsonwebtoken = { version = "10.2", features = ["rust_crypto"] }
 itertools = "0.15"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3.21"
@@ -74,3 +76,9 @@ tempfile = "3.21"
 testcontainers = "0.27"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["compat"] }
+
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dev-dependencies]
+jsonwebtoken-openssl = "1.0"
+
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "ios"))'.dev-dependencies]
+jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ mod test_helpers {
 
     pub(crate) fn jsonwebtoken_install_default_crypto_provider() {
         PROVIDER_INIT.get_or_init(|| {
+            #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))]
+            let _ = jsonwebtoken_openssl::install_default();
+            #[cfg(any(target_os = "windows", target_os = "macos", target_os = "ios"))]
             let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
         });
     }


### PR DESCRIPTION
native-tls feature should ideally use the platform specific tls instead of `rust-crypto`. For linux, its openssl. `jsonwebtoken-openssl` is a new crate which exposes this functionality for the linux platform.

This PR introduces the change to change the dependency of native-tls to this new crate.

In the production build, rust-oci-client uses jsonwebtoken's `dangerous::insecure_decode` method to parse expiration date from the jwt, which doesn't rely on a cryptobackend, but the dev dependencies include real crypto provider tests for verifying and encoding header, claims and key to a token.